### PR TITLE
GCC 8 compatibility

### DIFF
--- a/src/brownian_diffusive_flux.cc
+++ b/src/brownian_diffusive_flux.cc
@@ -33,7 +33,7 @@ void BrownianDiffusiveFlux::compute(std::shared_ptr<GrandPotential> grand, std::
         auto flux = fluxes_.at(t)->data();
 
         #ifdef FLYFT_OPENMP
-        #pragma omp parallel for schedule(static) default(none) shared(D,rho,mu_ex,V,dx,shape,flux)
+        #pragma omp parallel for schedule(static) default(none) firstprivate(D,dx,shape) shared(rho,mu_ex,V,flux)
         #endif
         for (int idx=0; idx < shape; ++idx)
             {

--- a/src/composite_external_potential.cc
+++ b/src/composite_external_potential.cc
@@ -27,7 +27,7 @@ void CompositeExternalPotential::potential(std::shared_ptr<Field> V, const std::
 
         const auto shape = mesh->shape();
         #ifdef FLYFT_OPENMP
-        #pragma omp parallel for schedule(static) default(none) shared(data,tmp,shape)
+        #pragma omp parallel for schedule(static) default(none) firstprivate(shape) shared(data,tmp)
         #endif
         for (int idx=0; idx < shape; ++idx)
             {

--- a/src/composite_flux.cc
+++ b/src/composite_flux.cc
@@ -29,7 +29,7 @@ void CompositeFlux::compute(std::shared_ptr<GrandPotential> grand, std::shared_p
 
             const auto shape = mesh->shape();
             #ifdef FLYFT_OPENMP
-            #pragma omp parallel for schedule(static) default(none) shared(j,jo,shape)
+            #pragma omp parallel for schedule(static) default(none) firstprivate(shape) shared(j,jo)
             #endif
             for (int idx=0; idx < shape; ++idx)
                 {

--- a/src/composite_functional.cc
+++ b/src/composite_functional.cc
@@ -36,7 +36,7 @@ void CompositeFunctional::compute(std::shared_ptr<State> state)
 
             const auto shape = mesh->shape();
             #ifdef FLYFT_OPENMP
-            #pragma omp parallel for schedule(static) default(none) shared(d,df,shape)
+            #pragma omp parallel for schedule(static) default(none) firstprivate(shape) shared(d,df)
             #endif
             for (int idx=0; idx < shape; ++idx)
                 {

--- a/src/explicit_euler_integrator.cc
+++ b/src/explicit_euler_integrator.cc
@@ -34,7 +34,7 @@ bool ExplicitEulerIntegrator::advance(std::shared_ptr<Flux> flux,
             const auto dx = mesh->step();
             const auto shape = mesh->shape();
             #ifdef FLYFT_OPENMP
-            #pragma omp parallel for schedule(static) default(none) shared(time_sign,dt,rho,j,dx,shape)
+            #pragma omp parallel for schedule(static) default(none) firstprivate(time_sign,dt,dx,shape) shared(rho,j)
             #endif
             for (int idx=0; idx < shape; ++idx)
                 {

--- a/src/exponential_wall_potential.cc
+++ b/src/exponential_wall_potential.cc
@@ -10,17 +10,18 @@ void ExponentialWallPotential::potential(std::shared_ptr<Field> V, const std::st
     const auto kappa = kappas_.at(type);
     const auto shift = shifts_.at(type);
     const double x0 = origin_->evaluate(state) + shift;
+    const auto normal = normal_;
 
     const auto mesh = *(state->getMesh());
     auto data = V->data();
 
     #ifdef FLYFT_OPENMP
-    #pragma omp parallel for schedule(static) default(none) shared(epsilon,kappa,x0,mesh,data,normal_)
+    #pragma omp parallel for schedule(static) default(none) firstprivate(epsilon,kappa,shift,x0,normal,mesh) shared(data)
     #endif
     for (int idx=0; idx < mesh.shape(); ++idx)
         {
         const auto x = mesh.coordinate(idx);
-        const double dx = normal_*(x-x0);
+        const double dx = normal*(x-x0);
         data[idx] = epsilon*std::exp(-kappa*dx);
         }
     }

--- a/src/fourier_transform.cc
+++ b/src/fourier_transform.cc
@@ -55,7 +55,7 @@ void FourierTransform::setRealData(const double* data)
     {
     const auto size = getRealSize();
     #ifdef FLYFT_OPENMP
-    #pragma omp parallel for schedule(static) default(none) shared(size,data_,data)
+    #pragma omp parallel for schedule(static) default(none) firstprivate(size) shared(data_,data)
     #endif
     for (int idx=0; idx < size; ++idx)
         {
@@ -83,7 +83,7 @@ void FourierTransform::setReciprocalData(const std::complex<double>* data)
     auto p = reinterpret_cast<const double*>(data);
     const auto size = 2*getReciprocalSize();
     #ifdef FLYFT_OPENMP
-    #pragma omp parallel for schedule(static) default(none) shared(size,data_,p)
+    #pragma omp parallel for schedule(static) default(none) firstprivate(size) shared(data_,p)
     #endif
     for (int idx=0; idx < size; ++idx)
         {

--- a/src/grand_potential.cc
+++ b/src/grand_potential.cc
@@ -42,7 +42,7 @@ void GrandPotential::compute(std::shared_ptr<State> state)
 
         const auto shape = mesh->shape();
         #ifdef FLYFT_OPENMP
-        #pragma omp parallel for schedule(static) default(none) shared(d,did,dex,dext,shape)
+        #pragma omp parallel for schedule(static) default(none) firstprivate(shape) shared(d,did,dex,dext)
         #endif
         for (int idx=0; idx < shape; ++idx)
             {
@@ -57,11 +57,11 @@ void GrandPotential::compute(std::shared_ptr<State> state)
         auto constraint_type = constraint_types_.at(t);
         if (constraint_type == Constraint::mu)
             {
-            auto mu_bulk = constraints_.at(t);
+            const auto mu_bulk = constraints_.at(t);
             auto rho = state->getField(t)->data();
             const auto dx = mesh->step();
             #ifdef FLYFT_OPENMP
-            #pragma omp parallel for schedule(static) default(none) shared(shape,dx,mu_bulk,rho,d) reduction(-:value_)
+            #pragma omp parallel for schedule(static) default(none) firstprivate(shape,dx,mu_bulk) shared(rho,d) reduction(-:value_)
             #endif
             for (int idx=0; idx < shape; ++idx)
                 {

--- a/src/hard_wall_potential.cc
+++ b/src/hard_wall_potential.cc
@@ -10,17 +10,18 @@ void HardWallPotential::potential(std::shared_ptr<Field> V, const std::string& t
     // edge where sphere contacts the wall
     const double R = 0.5*diameters_.at(type);
     const double edge = origin_->evaluate(state) + normal_*R;
+    const auto normal = normal_;
 
     const auto mesh = *(state->getMesh());
     auto data = V->data();
 
     #ifdef FLYFT_OPENMP
-    #pragma omp parallel for schedule(static) default(none) shared(mesh,normal_,edge,data)
+    #pragma omp parallel for schedule(static) default(none) firstprivate(mesh,edge,normal) shared(data)
     #endif
     for (int idx=0; idx < mesh.shape(); ++idx)
         {
         const auto x = mesh.coordinate(idx);
-        data[idx] = (normal_*(x-edge) < 0) ? std::numeric_limits<double>::infinity() : 0.0;
+        data[idx] = (normal*(x-edge) < 0) ? std::numeric_limits<double>::infinity() : 0.0;
         }
     }
 

--- a/src/harmonic_wall_potential.cc
+++ b/src/harmonic_wall_potential.cc
@@ -9,16 +9,17 @@ void HarmonicWallPotential::potential(std::shared_ptr<Field> V, const std::strin
     const auto k = spring_constants_.at(type);
     const auto shift = shifts_.at(type);
     const double x0 = origin_->evaluate(state) + shift;
+    const auto normal = normal_;
 
     const auto mesh = *(state->getMesh());
     auto data = V->data();
     #ifdef FLYFT_OPENMP
-    #pragma omp parallel for schedule(static) default(none) shared(mesh,k,x0,data)
+    #pragma omp parallel for schedule(static) default(none) firstprivate(k,x0,normal,mesh) shared(data)
     #endif
     for (int idx=0; idx < mesh.shape(); ++idx)
         {
         const auto x = mesh.coordinate(idx);
-        const double dx = normal_*(x-x0);
+        const double dx = normal*(x-x0);
 
         // potential acts only if dx < 0 (x is "inside" the wall)
         data[idx] = (dx < 0) ? 0.5*k*dx*dx : 0.0;

--- a/src/ideal_gas_functional.cc
+++ b/src/ideal_gas_functional.cc
@@ -21,7 +21,7 @@ void IdealGasFunctional::compute(std::shared_ptr<State> state)
         const auto shape = mesh->shape();
         const auto dx = mesh->step();
         #ifdef FLYFT_OPENMP
-        #pragma omp parallel for schedule(static) default(none) shared(f,d,shape,dx,vol) reduction(+:value_)
+        #pragma omp parallel for schedule(static) default(none) firstprivate(shape,dx,vol) shared(f,d) reduction(+:value_)
         #endif
         for (int idx=0; idx < shape; ++idx)
             {

--- a/src/lennard_jones_93_wall_potential.cc
+++ b/src/lennard_jones_93_wall_potential.cc
@@ -12,6 +12,7 @@ void LennardJones93WallPotential::potential(std::shared_ptr<Field> V, const std:
     const auto sigma = sigmas_.at(type);
     const auto cutoff = cutoffs_.at(type);
     const auto x0 = origin_->evaluate(state);
+    const auto normal = normal_;
 
     // precompute energy shift
     bool shift = shifts_.at(type);
@@ -33,12 +34,12 @@ void LennardJones93WallPotential::potential(std::shared_ptr<Field> V, const std:
     auto data = V->data();
 
     #ifdef FLYFT_OPENMP
-    #pragma omp parallel for schedule(static) default(none) shared(mesh,data,epsilon,sigma,cutoff,x0,normal_,energy_shift)
+    #pragma omp parallel for schedule(static) default(none) firstprivate(epsilon,sigma,cutoff,x0,energy_shift,normal,mesh) shared(data)
     #endif
     for (int idx=0; idx < mesh.shape(); ++idx)
         {
         const auto x = mesh.coordinate(idx);
-        const double dx = normal_*(x-x0);
+        const double dx = normal*(x-x0);
 
         // get 9 & 3 parts scaled by sigma
         double energy;

--- a/src/linear_potential.cc
+++ b/src/linear_potential.cc
@@ -7,15 +7,15 @@ void LinearPotential::potential(std::shared_ptr<Field> V,
                                 const std::string& type,
                                 std::shared_ptr<State> state)
     {
-    auto x0 = xs_.at(type);
-    auto y0 = ys_.at(type);
-    auto m = slopes_.at(type);
+    const auto x0 = xs_.at(type);
+    const auto y0 = ys_.at(type);
+    const auto m = slopes_.at(type);
 
     const auto mesh = *(state->getMesh());
     auto data = V->data();
 
     #ifdef FLYFT_OPENMP
-    #pragma omp parallel for schedule(static) default(none) shared(mesh,data,y0,m,x0)
+    #pragma omp parallel for schedule(static) default(none) firstprivate(x0,y0,m,mesh) shared(data)
     #endif
     for (int idx=0; idx < mesh.shape(); ++idx)
         {

--- a/src/picard_iteration.cc
+++ b/src/picard_iteration.cc
@@ -16,9 +16,9 @@ PicardIteration::PicardIteration(double mix_param,
 
 bool PicardIteration::solve(std::shared_ptr<GrandPotential> grand, std::shared_ptr<State> state)
     {
-    auto mesh = state->getMesh();
-    auto alpha = getMixParameter();
-    auto tol = getTolerance();
+    const auto mesh = state->getMesh();
+    const auto alpha = getMixParameter();
+    const auto tol = getTolerance();
 
     Field tmp(mesh->shape());
     bool converged = false;
@@ -52,7 +52,7 @@ bool PicardIteration::solve(std::shared_ptr<GrandPotential> grand, std::shared_p
                 auto N = grand->getConstraint(t);
                 double sum = 0.0;
                 #ifdef FLYFT_OPENMP
-                #pragma omp parallel for schedule(static) default(none) shared(shape,mu_ex,V,rho_tmp) reduction(+:sum)
+                #pragma omp parallel for schedule(static) default(none) firstprivate(shape) shared(mu_ex,V,rho_tmp) reduction(+:sum)
                 #endif
                 for (int idx=0; idx < shape; ++idx)
                     {
@@ -68,9 +68,9 @@ bool PicardIteration::solve(std::shared_ptr<GrandPotential> grand, std::shared_p
                 }
             else if (constraint_type == GrandPotential::Constraint::mu)
                 {
-                auto mu_bulk = grand->getConstraint(t);
+                const auto mu_bulk = grand->getConstraint(t);
                 #ifdef FLYFT_OPENMP
-                #pragma omp parallel for schedule(static) default(none) shared(shape,mu_ex,V,rho_tmp,mu_bulk)
+                #pragma omp parallel for schedule(static) default(none) firstprivate(shape,mu_bulk) shared(mu_ex,V,rho_tmp)
                 #endif
                 for (int idx=0; idx < shape; ++idx)
                     {
@@ -90,7 +90,7 @@ bool PicardIteration::solve(std::shared_ptr<GrandPotential> grand, std::shared_p
             // apply Picard mixing along with appropriate norm on value
             // during the same loop while checking convergence
             #ifdef FLYFT_OPENMP
-            #pragma omp parallel for schedule(static) default(none) shared(shape,rho,rho_tmp,converged,alpha,norm,tol)
+            #pragma omp parallel for schedule(static) default(none) firstprivate(shape,alpha,norm,tol) shared(rho,rho_tmp,converged)
             #endif
             for (int idx=0; idx < shape; ++idx)
                 {

--- a/src/rosenfeld_fmt.cc
+++ b/src/rosenfeld_fmt.cc
@@ -48,12 +48,12 @@ void RosenfeldFMT::compute(std::shared_ptr<State> state)
             // fft the density
             ft_->setRealData(state->getField(t)->data());
             ft_->transform();
-            const auto rhok = ft_->getReciprocalData();
+            auto rhok = ft_->getReciprocalData();
 
             // accumulate the fourier transformed densities into n
             const auto size = ft_->getReciprocalSize();
             #ifdef FLYFT_OPENMP
-            #pragma omp parallel for schedule(static) default(none) shared(R,size,kmesh,rhok,n0k,n1k,n2k,n3k,nv1k,nv2k)
+            #pragma omp parallel for schedule(static) default(none) firstprivate(R,size,kmesh) shared(rhok,n0k,n1k,n2k,n3k,nv1k,nv2k)
             #endif
             for (int idx=0; idx < size; ++idx)
                 {
@@ -121,7 +121,7 @@ void RosenfeldFMT::compute(std::shared_ptr<State> state)
         //////////////// The functions in here could be templated out too
         const auto shape = mesh->shape();
         #ifdef FLYFT_OPENMP
-        #pragma omp parallel for schedule(static) default(none) shared(shape,n0,n1,n2,n3,nv1,nv2,phi,dphi_dn0,dphi_dn1,dphi_dn2,dphi_dn3,dphi_dnv1,dphi_dnv2)
+        #pragma omp parallel for schedule(static) default(none) firstprivate(shape) shared(n0,n1,n2,n3,nv1,nv2,phi,dphi_dn0,dphi_dn1,dphi_dn2,dphi_dn3,dphi_dnv1,dphi_dnv2)
         #endif
         for (int idx=0; idx < shape; ++idx)
             {
@@ -213,8 +213,8 @@ void RosenfeldFMT::compute(std::shared_ptr<State> state)
 
             const auto size = ft_->getReciprocalSize();
             #ifdef FLYFT_OPENMP
-            #pragma omp parallel for schedule(static) default(none) shared(size,kmesh,derivativek,dphi_dn0k,\
-            dphi_dn1k,dphi_dn2k,dphi_dn3k,dphi_dnv1k,dphi_dnv2k,R)
+            #pragma omp parallel for schedule(static) default(none) firstprivate(size,kmesh,R) \
+            shared(derivativek,dphi_dn0k,dphi_dn1k,dphi_dn2k,dphi_dn3k,dphi_dnv1k,dphi_dnv2k)
             #endif
             for (int idx=0; idx < size; ++idx)
                 {

--- a/src/virial_expansion.cc
+++ b/src/virial_expansion.cc
@@ -34,7 +34,7 @@ void VirialExpansion::compute(std::shared_ptr<State> state)
             const auto shape = mesh->shape();
             const auto dx = mesh->step();
             #ifdef FLYFT_OPENMP
-            #pragma omp parallel for schedule(static) default(none) shared(fi,di,fj,dj,Bij,shape,dx) reduction(+:value_)
+            #pragma omp parallel for schedule(static) default(none) firstprivate(Bij,shape,dx) shared(fi,di,fj,dj) reduction(+:value_)
             #endif
             for (int idx=0; idx < shape; ++idx)
                 {


### PR DESCRIPTION
Move const variables to firstprivate clause

In GCC < 9, const variables are implied shared and it is an error (!!)
to explicitly make them shared.

In GCC >= 9, const variables need to be explicitly added to the clause.

For compatibility with both compiler eras, const variables can be
moved to a firstprivate clause. The threads don't really need their
own private copy, but it still works.

https://gcc.gnu.org/gcc-9/porting_to.html#ompdatasharing