### PR TITLE
Make sliced meshes give same results as full meshes

### DIFF
--- a/include/flyft/cartesian_mesh.h
+++ b/include/flyft/cartesian_mesh.h
@@ -10,14 +10,15 @@ class CartesianMesh: public Mesh
     {
     public: 
         CartesianMesh(double lower_bound, double upper_bound, int shape, BoundaryType lower_bc, BoundaryType upper_bc, double area);
-        
-        std::shared_ptr<Mesh> slice(int start, int end) const override;
 
         double area(int i) const override;
         double volume() const override; 
         double volume(int i) const override;  
         double gradient(int idx, double f_lo, double f_hi) const override; 
-    
+
+    protected:
+        std::shared_ptr<Mesh> clone() const override;
+
     private:
         double area_; //<! Cross sectional area
     };

--- a/include/flyft/mesh.h
+++ b/include/flyft/mesh.h
@@ -15,7 +15,7 @@ class Mesh
         Mesh() = delete;
         Mesh(double lower_bound, double upper_bound, int shape, BoundaryType lower_bc, BoundaryType upper_bc);
 
-        virtual std::shared_ptr<Mesh> slice(int start, int end) const = 0;
+        std::shared_ptr<Mesh> slice(int start, int end) const;
 
         //! Get position on the mesh, defined as center of bin
         double center(int i) const;
@@ -83,16 +83,16 @@ class Mesh
         bool operator!=(const Mesh& other) const;
 
     protected:
-        double lower_;    
-        double upper_;
+        double lower_;
         int shape_;     //!< Shape of the mesh
         BoundaryType lower_bc_;
         BoundaryType upper_bc_;
-        
-        double L_;      //!< Length of the domain
         double step_;   //!< Spacing between mesh points
+        int start_;
         
         void validateBoundaryCondition() const;
+
+        virtual std::shared_ptr<Mesh> clone() const = 0;
     };
 
 }

--- a/include/flyft/spherical_mesh.h
+++ b/include/flyft/spherical_mesh.h
@@ -11,8 +11,6 @@ class SphericalMesh : public Mesh
     public:
         SphericalMesh(double lower_bound, double upper_bound, int shape, BoundaryType lower_bc, BoundaryType upper_bc);  
 
-        std::shared_ptr<Mesh> slice(int start, int end) const override;
-
         double area(int i) const override;
         double volume() const override;
         double volume(int i) const override;
@@ -20,6 +18,7 @@ class SphericalMesh : public Mesh
     
     protected:
         void validateBoundaryCondition() const;
+        std::shared_ptr<Mesh> clone() const override;
     };
 }
 

--- a/python/flyft/_flyft/mesh.cc
+++ b/python/flyft/_flyft/mesh.cc
@@ -9,11 +9,6 @@ class MeshTrampoline : public Mesh
     {
     public:
         using Mesh::Mesh;
-
-        std::shared_ptr<Mesh> slice(int start, int end) const override
-            {
-            PYBIND11_OVERRIDE_PURE(std::shared_ptr<Mesh>, Mesh, slice, start, end);
-            }
         
         double area(int i) const override
             {
@@ -33,6 +28,12 @@ class MeshTrampoline : public Mesh
         double gradient(int idx, double f_lo, double f_hi) const override
             {
             PYBIND11_OVERRIDE_PURE(double, Mesh, gradient, idx, f_lo, f_hi);
+            }
+
+    protected:
+        std::shared_ptr<Mesh> clone() const override
+            {
+            PYBIND11_OVERRIDE_PURE(std::shared_ptr<Mesh>, Mesh, clone);
             }
     };
 

--- a/python/tests/test_brownian_diffusive_flux.py
+++ b/python/tests/test_brownian_diffusive_flux.py
@@ -144,7 +144,9 @@ def test_external(state,grand,ig,walls,linear,bd):
     state.fields['A'][inside] = 1.0+slope*(x[inside]-walls[0].origin)
     grand.constrain('A', np.sum(state.fields['A'])*state.mesh.full.step, grand.Constraint.N)
     bd.compute(grand,state)
-    assert np.allclose(bd.fluxes['A'][3:-2], -2.0*slope)
+    lower = np.array([state.mesh.local.lower_bound(i) for i in range(state.mesh.local.shape)])
+    flags = np.logical_and(lower > walls[0].origin, lower < walls[1].origin)
+    assert np.allclose(bd.fluxes['A'][flags], -2.0*slope)
 
     # use linear potential to check gradient calculation between walls
     state.fields['A'][inside] = 3.
@@ -152,4 +154,4 @@ def test_external(state,grand,ig,walls,linear,bd):
     linear.set_line('A', x=walls[0].origin, y=0., slope=0.25)
     grand.external.append(linear)
     bd.compute(grand,state)
-    assert np.allclose(bd.fluxes['A'][3:-2], 3.*2.*-0.25)
+    assert np.allclose(bd.fluxes['A'][flags], 3.*2.*-0.25)

--- a/python/tests/test_crank_nicolson_integrator.py
+++ b/python/tests/test_crank_nicolson_integrator.py
@@ -53,9 +53,10 @@ def test_advance(state,grand,ig,linear,bd,cn):
         # except near the edges where the potential seems discontinuous by finite difference
         linear.set_line('A', x=0., y=0., slope=0.25)
         grand.external = linear
+        bd.compute(grand, state)
         cn.advance(bd, grand, state, cn.timestep)
         assert state.time == pytest.approx(1.e-3)
-        assert np.allclose(state.fields['A'][1:-1], 1.0, atol=1e-4)
+        assert np.allclose(state.fields['A'][2:-2], 1.0, atol=1e-4)
 
     # run forwards multiple steps
     state.time = 0.

--- a/python/tests/test_explicit_euler_integrator.py
+++ b/python/tests/test_explicit_euler_integrator.py
@@ -41,12 +41,10 @@ def test_advance(state,grand,ig,linear,bd,euler):
         grand.external = linear
         euler.advance(bd, grand, state, euler.timestep)
         assert state.time == pytest.approx(1.e-3)
-
-        x = state.mesh.local.centers
-        flags = np.logical_and(x >= state.mesh.full.centers[1], x <= state.mesh.full.centers[-2])
-        assert np.allclose(state.fields['A'][flags], 1.0)
+        assert np.allclose(state.fields['A'][1:-1], 1.0)
 
         # check everywhere using the flux computed by bd
+        x = state.mesh.local.centers
         state.fields['A'][:] = 1.0
         bd.compute(grand,state)
         xfull = state.mesh.full.centers

--- a/python/tests/test_implicit_euler_integrator.py
+++ b/python/tests/test_implicit_euler_integrator.py
@@ -55,7 +55,7 @@ def test_advance(state,grand,ig,linear,bd,euler):
         grand.external = linear
         euler.advance(bd, grand, state, euler.timestep)
         assert state.time == pytest.approx(1.e-3)
-        assert np.allclose(state.fields['A'][1:-1], 1.0, atol=1e-3)
+        assert np.allclose(state.fields['A'][2:-2], 1.0, atol=1e-3)
 
     # run forwards multiple steps
     state.time = 0.

--- a/src/cartesian_mesh.cc
+++ b/src/cartesian_mesh.cc
@@ -8,15 +8,9 @@ CartesianMesh::CartesianMesh(double lower_bound,double upper_bound,int shape, Bo
     {
     }
 
-std::shared_ptr<Mesh> CartesianMesh::slice(int start, int end) const
+std::shared_ptr<Mesh> CartesianMesh::clone() const
     {
-    return std::shared_ptr<Mesh>(new CartesianMesh(
-        lower_bound(start),
-        lower_bound(end),
-        end-start,
-        (start > 0) ? BoundaryType::internal : lower_bc_,
-        (end < shape_) ? BoundaryType::internal : upper_bc_,
-        area_));
+    return std::make_shared<CartesianMesh>(*this);
     }
 
 double CartesianMesh::area(int /*i*/) const
@@ -26,7 +20,7 @@ double CartesianMesh::area(int /*i*/) const
 
 double CartesianMesh::volume() const
     {
-    return area_*L_;
+    return area_*L();
     }
 
 double CartesianMesh::volume(int /*i*/) const

--- a/src/mesh.cc
+++ b/src/mesh.cc
@@ -6,45 +6,66 @@ namespace flyft
 {
 
 Mesh::Mesh(double lower_bound, double upper_bound, int shape, BoundaryType lower_bc, BoundaryType upper_bc)
-    : lower_(lower_bound), upper_(upper_bound), shape_(shape), lower_bc_(lower_bc), upper_bc_(upper_bc), L_(upper_-lower_), step_(L_/shape_)
+    : lower_(lower_bound), shape_(shape), lower_bc_(lower_bc), upper_bc_(upper_bc), start_(0)
     {
+    step_ = (upper_bound - lower_bound) / shape_;
     validateBoundaryCondition();
+    }
+
+std::shared_ptr<Mesh> Mesh::slice(int start, int end) const
+    {
+    if (lower_bc_ == BoundaryType::internal || upper_bc_ == BoundaryType::internal)
+        {
+        throw std::runtime_error("Cannot slice a Mesh more than once.");
+        }
+
+    auto m = clone();
+    m->start_ = start;
+    m->shape_ = end-start;
+    if (start > 0)
+        {
+        m->lower_bc_ = BoundaryType::internal;
+        }
+    if (end < shape_)
+        {
+        m->upper_bc_ = BoundaryType::internal;
+        }
+    return m;
     }
 
 double Mesh::center(int i) const
     {
-    return lower_+static_cast<double>(i+0.5)*step_;
+    return lower_+static_cast<double>(start_+i+0.5)*step_;
     }
 
 int Mesh::bin(double x) const
     {
-    return static_cast<int>((x-lower_)/step_);
+    return static_cast<int>((x-lower_)/step_) - start_;
     }
-
 
 double Mesh::lower_bound() const
     {
-    return lower_;
+    return lower_bound(0);
     }
   
 double Mesh::lower_bound(int i) const
     {
-    return lower_+static_cast<double>(i)*step_;
+    return lower_ + (start_+i)*step_;
     }
   
 double Mesh::upper_bound() const
     {
-    return upper_;
+    return lower_bound(start_ + shape_);
     }
     
 double Mesh::upper_bound(int i) const
     {
-    return lower_+static_cast<double>(i+1)*step_;
+    return lower_bound(i+1);
     }
         
 double Mesh::L() const
     {
-    return L_;
+    return asLength(shape_);
     }
 
 int Mesh::shape() const
@@ -155,9 +176,9 @@ double Mesh::gradient(int idx, const DataView<const double>& f) const
 
 bool Mesh::operator==(const Mesh& other) const
     {
-    return (typeid(*this) == typeid(other) && lower_ == other.lower_ 
-            && upper_ == other.upper_ && shape_ == other.shape_ 
-            && lower_bc_ == other.lower_bc_ && upper_bc_ == other.upper_bc_);
+    return (typeid(*this) == typeid(other) && lower_ == other.lower_  && shape_ == other.shape_ 
+            && lower_bc_ == other.lower_bc_ && upper_bc_ == other.upper_bc_
+            && start_ == other.start_);
     }
 
 bool Mesh::operator!=(const Mesh& other) const

--- a/src/spherical_mesh.cc
+++ b/src/spherical_mesh.cc
@@ -12,33 +12,28 @@ SphericalMesh::SphericalMesh(double lower_bound, double upper_bound,int shape, B
     }
 
 
-std::shared_ptr<Mesh> SphericalMesh::slice(int start, int end) const
+std::shared_ptr<Mesh> SphericalMesh::clone() const
     {
-    return std::shared_ptr<Mesh>(new SphericalMesh(
-        lower_bound(start),
-        lower_bound(end),
-        end-start, 
-        (start > 0) ? BoundaryType::internal : lower_bc_, 
-        (end < shape_) ? BoundaryType::internal : upper_bc_));
+    return std::make_shared<SphericalMesh>(*this);
     }
 
 double SphericalMesh::area(int i) const
     {
-    const double r = lower_bound(i);
+    const double r = lower_bound(start_ + i);
     return 4.*M_PI*r*r;
     }
 
 double SphericalMesh::volume() const
     {
-    const double rlo = lower_;
-    const double rhi = upper_;
+    const double rlo = lower_bound();
+    const double rhi = upper_bound();
     return (4.*M_PI/3.)*(rhi*rhi*rhi - rlo*rlo*rlo);
     }
     
 double SphericalMesh::volume(int i) const
     {
-    const double r_out = upper_bound(i);
-    const double r_in = lower_bound(i);
+    const double r_out = upper_bound(start_+i);
+    const double r_in = lower_bound(start_+i);
     return (4.*M_PI/3.)*(r_out*r_out*r_out - r_in*r_in*r_in);
     }
 


### PR DESCRIPTION
This PR fixes floating-point rounding errors that caused some sliced meshes to give different values than full meshes when floats were floored/ceiled. This caused an issue with the MPI buffer calculations, since different ranks gave different buffer sizes. The solution here is to always do floating point calculations relative to the same origin, but then reindex the integer values based on where a sliced mesh starts in the full domain.