### PR TITLE
Fix indexing of mesh bounds in MPI

### DIFF
--- a/include/flyft/mesh.h
+++ b/include/flyft/mesh.h
@@ -72,8 +72,8 @@ class Mesh
         double integrateVolume(int idx, const DataView<double>& f) const;
         double integrateVolume(int idx, const DataView<const double>& f) const;
 
-        double interpolate(double x, const DataView<double>& f) const;  
-        double interpolate(double x, const DataView<const double>& f) const;  
+        template<typename T>
+        typename std::remove_const<T>::type interpolate(double x, const DataView<T>& f) const;
         
         virtual double gradient(int idx, double f_lo, double f_hi) const = 0;
         double gradient(int idx, const DataView<const double>& f) const ;
@@ -94,6 +94,31 @@ class Mesh
 
         virtual std::shared_ptr<Mesh> clone() const = 0;
     };
+
+template<typename T>
+typename std::remove_const<T>::type Mesh::interpolate(double x, const DataView<T>& f) const
+    {
+    const auto idx = bin(x);
+    const auto x_c = center(idx);
+    double x_0, x_1;
+    typename std::remove_const<T>::type f_0, f_1;
+    if (x < x_c)
+        {
+        x_0 = center(idx - 1);
+        x_1 = x_c;
+        f_0 = f(idx - 1);
+        f_1 = f(idx);
+        }
+    else
+        {
+        x_0 = x_c;
+        x_1 = center(idx + 1);
+        f_0 = f(idx);
+        f_1 = f(idx + 1);
+        }
+
+    return f_0 + (x - x_0) * (f_1 - f_0) / (x_1 - x_0);
+    }
 
 }
 

--- a/src/mesh.cc
+++ b/src/mesh.cc
@@ -55,7 +55,7 @@ double Mesh::lower_bound(int i) const
   
 double Mesh::upper_bound() const
     {
-    return lower_bound(start_ + shape_);
+    return lower_bound(shape_);
     }
     
 double Mesh::upper_bound(int i) const

--- a/src/mesh.cc
+++ b/src/mesh.cc
@@ -118,35 +118,6 @@ double Mesh::integrateVolume(int idx, const DataView<const double>& f) const
     return integrateVolume(idx, f(idx));
     }
 
-double Mesh::interpolate(double x, const DataView<double>& f) const
-    {
-    return interpolate(x,f);
-    }
-
-double Mesh::interpolate(double x, const DataView<const double>& f) const
-    {
-    const auto idx = bin(x);
-    const auto x_c = center(idx);
-
-    double x_0, x_1, f_0, f_1;
-    if (x < x_c)
-        {
-        x_0 = center(idx - 1);
-        x_1 = x_c;
-        f_0 = f(idx - 1);
-        f_1 = f(idx);
-        }
-    else
-        {
-        x_0 = x_c;
-        x_1 = center(idx + 1);
-        f_0 = f(idx);
-        f_1 = f(idx + 1);
-        }
-
-    return f_0 + (x - x_0) * (f_1 - f_0) / (x_1 - x_0);
-    }
-
 double Mesh::gradient(int idx, const DataView<double>& f) const
     {
     if ((idx == 0 && lower_bc_ == BoundaryType::reflect) ||

--- a/src/spherical_mesh.cc
+++ b/src/spherical_mesh.cc
@@ -19,7 +19,7 @@ std::shared_ptr<Mesh> SphericalMesh::clone() const
 
 double SphericalMesh::area(int i) const
     {
-    const double r = lower_bound(start_ + i);
+    const double r = lower_bound(i);
     return 4.*M_PI*r*r;
     }
 
@@ -32,8 +32,8 @@ double SphericalMesh::volume() const
     
 double SphericalMesh::volume(int i) const
     {
-    const double r_out = upper_bound(start_+i);
-    const double r_in = lower_bound(start_+i);
+    const double r_out = upper_bound(i);
+    const double r_in = lower_bound(i);
     return (4.*M_PI/3.)*(r_out*r_out*r_out - r_in*r_in*r_in);
     }
 


### PR DESCRIPTION
These methods should use local indexing, otherwise they add `start_` too many times in MPI.